### PR TITLE
Fix broken newsletter link, make indentation consistent

### DIFF
--- a/newsletters.html
+++ b/newsletters.html
@@ -40,20 +40,20 @@
                     </p>
                     <h2 class="other-title">2023</h2>
                     <ul>
-                        <li><a href="static/files/pdf/newsletters/February%2023%20Newsletter.pdf" target="_blank">February 2023 Newsletter</a></li>
+                        <li><a href="static/files/pdf/newsletters/February%202023%20Newsletter.pdf" target="_blank">February 2023 Newsletter</a></li>
                     </ul>
                     <h2 class="other-title">2021</h2>
                     <ul>
                         <li><a href="static/files/pdf/newsletters/April%202021%20Newsletter.pdf" target="_blank">April 2021 Newsletter</a></li>
                     </ul>
                     <h2 class="other-title">2020</h2>
-                        <ul>
-                            <li><a href="static/files/pdf/newsletters/March%202020%20Newsletter.pdf" target="_blank">March 2020 Newsletter</a></li>
-                        </ul>
+                    <ul>
+                        <li><a href="static/files/pdf/newsletters/March%202020%20Newsletter.pdf" target="_blank">March 2020 Newsletter</a></li>
+                    </ul>
                     <h2 class="other-title">2019</h2>
-                        <ul>
-                            <li><a href="static/files/pdf/newsletters/December%202019%20Newsletter.pdf" target="_blank">December 2019 Newsletter</a></li>
-                        </ul>
+                    <ul>
+                        <li><a href="static/files/pdf/newsletters/December%202019%20Newsletter.pdf" target="_blank">December 2019 Newsletter</a></li>
+                    </ul>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
`%2023` encodes ` 23`, but `%202023` encodes ` 2023`.

Also fixed some of my own poor indentation from the past.